### PR TITLE
Fix LOD lights appearing at the wrong time

### DIFF
--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -1353,13 +1353,13 @@ void Init()
 
     // Make LOD lights appear at the appropriate time like on the console version (consoles: 7 PM, pc: 10 PM)
     {
-        auto pattern = hook::pattern("8D ? 13 3B ? 75 ? ? ? ? ? ? ? FF ? ?");
+        auto pattern = hook::pattern("8D 42 13");
         if (!pattern.empty()) injector::WriteMemory<uint8_t>(pattern.get_first(2), 0x10, true);
-        pattern = hook::pattern("? ? 14 3B ? 7D ? ? 06 00 00 00 2B ? ? ?");
+        pattern = hook::pattern("8D 42 14 3B C8");
         if (!pattern.empty()) injector::WriteMemory<uint8_t>(pattern.get_first(2), 0x10, true);
         if (!pattern.empty()) injector::WriteMemory<uint8_t>(pattern.get_first(8), 0x07, true);
         // Removing episode id check that resulted in flickering LOD lights at certain camera angles in TBOGT
-        pattern = hook::pattern("83 3D ? ? ? 01 02 0F ? ? ? ? ? F3 0F 10 ? ? ?");
+        pattern = hook::pattern("83 3D ? ? ? ? ? 0F 85 ? ? ? ? F3 0F 10 05 ? ? ? ? F3 0F 10 8C 24");
         if (!pattern.empty()) injector::MakeNOP(pattern.get_first(0), 150, true);
     }
 }

--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -1350,6 +1350,18 @@ void Init()
             }; injector::MakeInline<SetVertexShaderConstantFHook>(pattern.count(2).get(1).get<void*>(0), pattern.count(2).get(1).get<void*>(6));
         }
     }
+
+    // Make LOD lights appear at the appropriate time like on the console version (consoles: 7 PM, pc: 10 PM)
+    {
+        auto pattern = hook::pattern("8D ? 13 3B ? 75 ? ? ? ? ? ? ? FF ? ?");
+        if (!pattern.empty()) injector::WriteMemory<uint8_t>(pattern.get_first(2), 0x10, true);
+        pattern = hook::pattern("? ? 14 3B ? 7D ? ? 06 00 00 00 2B ? ? ?");
+        if (!pattern.empty()) injector::WriteMemory<uint8_t>(pattern.get_first(2), 0x10, true);
+        if (!pattern.empty()) injector::WriteMemory<uint8_t>(pattern.get_first(8), 0x07, true);
+        // Removing episode id check that resulted in flickering LOD lights at certain camera angles in TBOGT
+        pattern = hook::pattern("83 3D ? ? ? 01 02 0F ? ? ? ? ? F3 0F 10 ? ? ?");
+        if (!pattern.empty()) injector::MakeNOP(pattern.get_first(0), 150, true);
+    }
 }
 
 CEXP void InitializeASI()


### PR DESCRIPTION
- Restores the correct time at which LOD lights would appear based on how it worked on the console versions.
- Removing an episode ID check which would cause the LOD lights' corona size/intensity to change at certain camera angles in TBOGT which could be seen as flickering.

Notes: Might wanna check whether the wildcarding of the bytes or signatures themselves and the types are correct since I'm not really experienced in ASM, code injection or C++, though I tested this fix in-game and I didn't encounter any problems.