### PR TITLE
Remove free cam boundary limits in the video editor

### DIFF
--- a/source/fixes.ixx
+++ b/source/fixes.ixx
@@ -341,6 +341,18 @@ public:
                     }
                 };
             }
+
+            // Remove free cam boundary limits in the video editor, ported from from openCamera.
+            {
+                auto pattern = find_pattern("0F 86 ? ? ? ? 0F 2E FA 9F F6 C4 44 7A 05 0F 28 DA EB 07 0F 51 C7", "0F 86 ? ? ? ? F3 0F 10 54 24 ? 0F 2E D4 9F F6 C4 44 7A 05 0F 28 D4 EB 10");
+                injector::MakeJMP(pattern.get_first(), find_pattern("8D 84 24 ? ? ? ? 50 8D 4F 10 E8 ? ? ? ? F3 0F 10 AC 24", "8D 44 24 60 8D 7E 10 50 8B CF E8").get_first());
+
+                pattern = find_pattern("72 48 0F 2F 44 24 ? 72 41 0F 28 C3 0F 54 C2 0F 2F C8 72 36", "72 5F 0F 2F C5 72 5A 0F 2F FA 76 0E F3 0F 10 05");
+                injector::MakeJMP(pattern.get_first(), find_pattern("F3 0F 10 4C 24 ? F3 0F 10 94 24 ? ? ? ? F3 0F 11 BF ? ? ? ? F3 0F 11 A7", "F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? B3 01 E9").get_first());
+
+                pattern = find_pattern("72 6D 83 3D ? ? ? ? ? 74 1A A1 ? ? ? ? 3B 05 ? ? ? ? 75 0D", "0F 82 ? ? ? ? 83 3D ? ? ? ? ? 74 1A A1");
+                injector::MakeJMP(pattern.get_first(), find_pattern("8B 87 ? ? ? ? F3 0F 10 87 ? ? ? ? F3 0F 10 8F ? ? ? ? 8D 4F 40 6A 04 89 01", "D9 86 ? ? ? ? F3 0F 10 86 ? ? ? ? F3 0F 10 8E ? ? ? ? D9 5E 40 8D 46 40").get_first());
+            }
         };
     }
 } Fixes;

--- a/source/fixes.ixx
+++ b/source/fixes.ixx
@@ -342,16 +342,16 @@ public:
                 };
             }
 
-            // Remove free cam boundary limits in the video editor, ported from from openCamera.
+            // Remove free cam boundary limits in the video editor, ported from openCamera.
             {
-                auto pattern = find_pattern("0F 86 ? ? ? ? 0F 2E FA 9F F6 C4 44 7A 05 0F 28 DA EB 07 0F 51 C7", "0F 86 ? ? ? ? F3 0F 10 54 24 ? 0F 2E D4 9F F6 C4 44 7A 05 0F 28 D4 EB 10");
+                auto pattern = find_pattern("0F 86 ? ? ? ? 0F 2E FA 9F F6 C4 44 7A 05", "0F 86 ? ? ? ? F3 0F 10 54 24 ? 0F 2E D4");
                 injector::MakeJMP(pattern.get_first(), find_pattern("8D 84 24 ? ? ? ? 50 8D 4F 10 E8 ? ? ? ? F3 0F 10 AC 24", "8D 44 24 60 8D 7E 10 50 8B CF E8").get_first());
 
-                pattern = find_pattern("72 48 0F 2F 44 24 ? 72 41 0F 28 C3 0F 54 C2 0F 2F C8 72 36", "72 5F 0F 2F C5 72 5A 0F 2F FA 76 0E F3 0F 10 05");
-                injector::MakeJMP(pattern.get_first(), find_pattern("F3 0F 10 4C 24 ? F3 0F 10 94 24 ? ? ? ? F3 0F 11 BF ? ? ? ? F3 0F 11 A7", "F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? B3 01 E9").get_first());
+                pattern = find_pattern("72 48 0F 2F 44 24 ? 72 41 0F 28 C3 0F 54 C2", "72 5F 0F 2F C5 72 5A 0F 2F FA 76 0E F3 0F 10 05");
+                injector::MakeJMP(pattern.get_first(), find_pattern("F3 0F 10 4C 24 ? F3 0F 10 94 24 ? ? ? ? F3 0F 11 BF", "F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? F3 0F 10 44 24 ? F3 0F 11 86 ? ? ? ? B3 01").get_first());
 
-                pattern = find_pattern("72 6D 83 3D ? ? ? ? ? 74 1A A1 ? ? ? ? 3B 05 ? ? ? ? 75 0D", "0F 82 ? ? ? ? 83 3D ? ? ? ? ? 74 1A A1");
-                injector::MakeJMP(pattern.get_first(), find_pattern("8B 87 ? ? ? ? F3 0F 10 87 ? ? ? ? F3 0F 10 8F ? ? ? ? 8D 4F 40 6A 04 89 01", "D9 86 ? ? ? ? F3 0F 10 86 ? ? ? ? F3 0F 10 8E ? ? ? ? D9 5E 40 8D 46 40").get_first());
+                pattern = find_pattern("72 6D 83 3D ? ? ? ? ? 74 1A A1", "0F 82 ? ? ? ? 83 3D ? ? ? ? ? 74 1A");
+                injector::MakeJMP(pattern.get_first(), find_pattern("8B 87 ? ? ? ? F3 0F 10 87 ? ? ? ? F3 0F 10 8F ? ? ? ? 8D 4F 40", "D9 86 ? ? ? ? F3 0F 10 86 ? ? ? ? F3 0F 10 8E ? ? ? ? D9 5E 40").get_first());
             }
         };
     }


### PR DESCRIPTION
This was already implemented in [openCamera](https://openiv.com/?p=796) but wasn't updated since version 1.0.7.0.
This should make it compatible with later versions of the game, namely CE/1.0.8.0 (Tested on 1.0.7.0/1.0.8.0/CE)