### PR TITLE
Option to "always run" only while outside of interiors

### DIFF
--- a/data/update/TBoGT/common/data/frontend_menus.xml
+++ b/data/update/TBoGT/common/data/frontend_menus.xml
@@ -424,6 +424,13 @@
       <options text="FXAA" action="ACTION_NONE" value="2" />
       <options text="SMAA" action="ACTION_NONE" value="3" />
     </menupc>
+	
+	<menupc enum="MENU_DISPLAY_ALWAYSRUN">
+	  <options text="MO_OFF" action="ACTION_NONE" value="1" />
+	  <options text="On" action="ACTION_NONE" value="2" />
+	  <options text="Outside" action="ACTION_NONE" value="3" />
+	</menupc>
+		
   </sMenuDisplayValue>
   <sMenuScreen>
     <menu HeaderText="MH_GAM" enum="SCR_GAME">
@@ -481,7 +488,7 @@
       <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
       <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
       <optionspc action="MENUOPT_ADJUST" label="Raw Input" value="PREF_RAWINPUT" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
-      <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+      <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="6" displayValue="MENU_DISPLAY_ALWAYSRUN" />
       <optionspc action="MENUOPT_ADJUST" label="Cover Centering" value="PREF_COVERCENTERING" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
       <options action="END_OF_MENU_OPTIONS" label="" value="0" scaler="0" displayValue="0" />
     </menu>

--- a/data/update/TBoGT/common/data/frontend_menus.xml
+++ b/data/update/TBoGT/common/data/frontend_menus.xml
@@ -424,13 +424,13 @@
       <options text="FXAA" action="ACTION_NONE" value="2" />
       <options text="SMAA" action="ACTION_NONE" value="3" />
     </menupc>
-	
-	<menupc enum="MENU_DISPLAY_ALWAYSRUN">
-	  <options text="MO_OFF" action="ACTION_NONE" value="1" />
-	  <options text="On" action="ACTION_NONE" value="2" />
-	  <options text="Outside" action="ACTION_NONE" value="3" />
-	</menupc>
-		
+    
+    <menupc enum="MENU_DISPLAY_ALWAYSRUN">
+      <options text="MO_OFF" action="ACTION_NONE" value="1" />
+      <options text="MO_ON" action="ACTION_NONE" value="2" />
+      <options text="Outside" action="ACTION_NONE" value="3" />
+    </menupc>
+        
   </sMenuDisplayValue>
   <sMenuScreen>
     <menu HeaderText="MH_GAM" enum="SCR_GAME">

--- a/data/update/TLAD/common/data/frontend_menus.xml
+++ b/data/update/TLAD/common/data/frontend_menus.xml
@@ -500,6 +500,11 @@
       <options text="FXAA" action="ACTION_NONE" value="2" />
       <options text="SMAA" action="ACTION_NONE" value="3" />
     </menupc>
+	<menupc enum="MENU_DISPLAY_ALWAYSRUN">
+	  <options text="MO_OFF" action="ACTION_NONE" value="1" />
+	  <options text="On" action="ACTION_NONE" value="2" />
+	  <options text="Outside" action="ACTION_NONE" value="3" />
+	</menupc>
   </sMenuDisplayValue>
   <sMenuScreen>
     <menu HeaderText="MH_GAM" enum="SCR_GAME">
@@ -557,7 +562,7 @@
       <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
       <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
       <optionspc action="MENUOPT_ADJUST" label="Raw Input" value="PREF_RAWINPUT" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
-      <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+      <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="6" displayValue="MENU_DISPLAY_ALWAYSRUN" />
       <optionspc action="MENUOPT_ADJUST" label="Cover Centering" value="PREF_COVERCENTERING" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
       <options action="END_OF_MENU_OPTIONS" label="" value="0" scaler="0" displayValue="0" />
     </menu>

--- a/data/update/TLAD/common/data/frontend_menus.xml
+++ b/data/update/TLAD/common/data/frontend_menus.xml
@@ -500,11 +500,11 @@
       <options text="FXAA" action="ACTION_NONE" value="2" />
       <options text="SMAA" action="ACTION_NONE" value="3" />
     </menupc>
-	<menupc enum="MENU_DISPLAY_ALWAYSRUN">
-	  <options text="MO_OFF" action="ACTION_NONE" value="1" />
-	  <options text="On" action="ACTION_NONE" value="2" />
-	  <options text="Outside" action="ACTION_NONE" value="3" />
-	</menupc>
+    <menupc enum="MENU_DISPLAY_ALWAYSRUN">
+      <options text="MO_OFF" action="ACTION_NONE" value="1" />
+      <options text="MO_ON" action="ACTION_NONE" value="2" />
+      <options text="Outside" action="ACTION_NONE" value="3" />
+    </menupc>
   </sMenuDisplayValue>
   <sMenuScreen>
     <menu HeaderText="MH_GAM" enum="SCR_GAME">

--- a/data/update/common/data/frontend_menus.xml
+++ b/data/update/common/data/frontend_menus.xml
@@ -360,12 +360,12 @@
           <options text="SMAA" action="ACTION_NONE" value="3" />
         </menupc>
 
-		<menupc enum="MENU_DISPLAY_ALWAYSRUN">
+        <menupc enum="MENU_DISPLAY_ALWAYSRUN">
           <options text="MO_OFF" action="ACTION_NONE" value="1" />
-          <options text="On" action="ACTION_NONE" value="2" />
+          <options text="MO_ON" action="ACTION_NONE" value="2" />
           <options text="Outside" action="ACTION_NONE" value="3" />
         </menupc>
-		
+        
     </sMenuDisplayValue>
 
     <sMenuScreen>

--- a/data/update/common/data/frontend_menus.xml
+++ b/data/update/common/data/frontend_menus.xml
@@ -359,6 +359,13 @@
           <options text="FXAA" action="ACTION_NONE" value="2" />
           <options text="SMAA" action="ACTION_NONE" value="3" />
         </menupc>
+
+		<menupc enum="MENU_DISPLAY_ALWAYSRUN">
+          <options text="MO_OFF" action="ACTION_NONE" value="1" />
+          <options text="On" action="ACTION_NONE" value="2" />
+          <options text="Outside" action="ACTION_NONE" value="3" />
+        </menupc>
+		
     </sMenuDisplayValue>
 
     <sMenuScreen>
@@ -422,7 +429,7 @@
             <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             <optionspc action="MENUOPT_ADJUST" label="Raw Input" value="PREF_RAWINPUT" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
-            <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+            <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="6" displayValue="MENU_DISPLAY_ALWAYSRUN" />
             <optionspc action="MENUOPT_ADJUST" label="Cover Centering" value="PREF_COVERCENTERING" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <options action="END_OF_MENU_OPTIONS" label="" value="0" scaler="0" displayValue="0" />
         </menu>
@@ -861,7 +868,7 @@
             <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             <optionspc action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             <optionspc action="MENUOPT_ADJUST" label="Raw Input" value="PREF_RAWINPUT" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
-            <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+            <optionspc action="MENUOPT_ADJUST" label="Always Run" value="PREF_ALWAYSRUN" scaler="6" displayValue="MENU_DISPLAY_ALWAYSRUN" />
             <optionspc action="MENUOPT_ADJUST" label="Cover Centering" value="PREF_COVERCENTERING" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <options action="END_OF_MENU_OPTIONS" label="" value="0" scaler="0" displayValue="MENU_DISPLAY_NONE" />
         </menupc>

--- a/source/ikeeponwalking.ixx
+++ b/source/ikeeponwalking.ixx
@@ -37,7 +37,7 @@ public:
                         *(uintptr_t*)(regs.esp - 4) = loc_A2A60F;
                     }
                     auto alwaysrunPref = FusionFixSettings.GetRef("PREF_ALWAYSRUN"); 
-                    bool shouldRun = (alwaysrunPref->get() == FusionFixSettings.AlwaysRunText.eOn
+                    bool shouldRun = (alwaysrunPref->get() == FusionFixSettings.AlwaysRunText.eMO_ON
                         || (alwaysrunPref->get() == FusionFixSettings.AlwaysRunText.eOutside && !Natives::IsInteriorScene()));
 
                     if (!FusionFixSettings.Get("PREF_SPRINT")) // toggle

--- a/source/ikeeponwalking.ixx
+++ b/source/ikeeponwalking.ixx
@@ -43,7 +43,7 @@ public:
                     if (!FusionFixSettings.Get("PREF_SPRINT")) // toggle
                     {
                         if (shouldRun)
-                        { 
+                        {
                             static auto bRunState = true;
                             static auto oldWalkKeyState = GetAsyncKeyState(nWalkKey);
                             auto curWalkKeyState = GetAsyncKeyState(nWalkKey);

--- a/source/ikeeponwalking.ixx
+++ b/source/ikeeponwalking.ixx
@@ -6,6 +6,7 @@ export module ikeeponwalking;
 
 import common;
 import settings;
+import natives;
 
 class IKeepOnWalking
 {
@@ -35,12 +36,14 @@ public:
 
                         *(uintptr_t*)(regs.esp - 4) = loc_A2A60F;
                     }
+                    auto alwaysrunPref = FusionFixSettings.GetRef("PREF_ALWAYSRUN"); 
+                    bool shouldRun = (alwaysrunPref->get() == FusionFixSettings.AlwaysRunText.eOn
+                        || (alwaysrunPref->get() == FusionFixSettings.AlwaysRunText.eOutside && !Natives::IsInteriorScene()));
 
-                    static auto alwaysrun = FusionFixSettings.GetRef("PREF_ALWAYSRUN");                    
                     if (!FusionFixSettings.Get("PREF_SPRINT")) // toggle
                     {
-                        if (alwaysrun->get())
-                        {
+                        if (shouldRun)
+                        { 
                             static auto bRunState = true;
                             static auto oldWalkKeyState = GetAsyncKeyState(nWalkKey);
                             auto curWalkKeyState = GetAsyncKeyState(nWalkKey);
@@ -52,7 +55,7 @@ public:
                                 *(float*)(regs.esp + (flag ? 0x18 : 0x1C)) = 1.0f;
                         }
                     }
-                    else if (alwaysrun->get() && !GetAsyncKeyState(nWalkKey)) // hold
+                    else if (shouldRun && !GetAsyncKeyState(nWalkKey)) // hold
                         *(float*)(regs.esp + (flag ? 0x18 : 0x1C)) = 1.0f;
                 }
             }; injector::MakeInline2<SprintHook>(pattern.get_first(0));

--- a/source/settings.ixx
+++ b/source/settings.ixx
@@ -201,7 +201,6 @@ public:
         for (auto i = 0; originalEnums[i].prefID < *pOriginalEnumsNum; i++)
         {
             aMenuEnums.emplace_back(originalEnums[i].prefID, originalEnums[i].name);
-
         }
         aMenuEnums.reserve(aMenuEnums.size() * 2);
         auto firstEnumCustomID = aMenuEnums.back().prefID + 1;

--- a/source/settings.ixx
+++ b/source/settings.ixx
@@ -154,7 +154,6 @@ public:
             { 0, "PREF_DEFINITION",        "MAIN",       "Definition",                      "MENU_DISPLAY_DEFINITION",    6, nullptr, DefinitionText.eClassic, std::distance(std::begin(DefinitionText.data), std::end(DefinitionText.data)) - 1 },
             { 0, "PREF_BLOOM",             "MAIN",       "Bloom",                           "",                           1, nullptr, 0, 1 },
             { 0, "PREF_FPSCOUNTER",        "FRAMELIMIT", "DisplayFpsCounter",               "",                           0, nullptr, 0, 1 },
-            { 0, "PREF_ALWAYSRUN",         "MISC",       "AlwaysRun",                       "",                           0, nullptr, 0, 1 },
             { 0, "PREF_ALTDIALOGUE",       "MISC",       "AltDialogue",                     "",                           0, nullptr, 0, 1 },
             { 0, "PREF_COVERCENTERING",    "MISC",       "CameraCenteringInCover",          "",                           0, nullptr, 0, 1 },
             { 0, "PREF_KBCAMCENTERDELAY",  "MISC",       "DelayBeforeCenteringCameraKB",    "",                           0, nullptr, 0, 9 },
@@ -164,7 +163,8 @@ public:
             { 0, "PREF_BUTTONS",           "MISC",       "Buttons",                         "MENU_DISPLAY_BUTTONS",       6, nullptr, ButtonsText.eXbox360, std::distance(std::begin(ButtonsText.data), std::end(ButtonsText.data)) - 1 },
             { 0, "PREF_LETTERBOX",         "MISC",       "Letterbox",                       "",                           1, nullptr, 0, 1 },
             { 0, "PREF_PILLARBOX",         "MISC",       "Pillarbox",                       "",                           1, nullptr, 0, 1 },
-            { 0, "PREF_ANTIALIASING",      "MISC",       "Antialiasing",                    "MENU_DISPLAY_ANTIALIASING",  5, nullptr, AntialiasingText.eMO_OFF, std::distance(std::begin(AntialiasingText.data), std::end(AntialiasingText.data)) - 1 },
+            { 0, "PREF_ANTIALIASING",      "MISC",       "Antialiasing",                    "MENU_DISPLAY_ANTIALIASING",  1, nullptr, AntialiasingText.eMO_OFF, std::distance(std::begin(AntialiasingText.data), std::end(AntialiasingText.data)) - 1 },
+            { 0, "PREF_ALWAYSRUN",         "MISC",       "AlwaysRun",                       "MENU_DISPLAY_ALWAYSRUN",     1, nullptr, AlwaysRunText.eMO_OFF, std::distance(std::begin(AlwaysRunText.data), std::end(AlwaysRunText.data)) - 1  },
         };
 
         auto i = firstCustomID;
@@ -201,6 +201,7 @@ public:
         for (auto i = 0; originalEnums[i].prefID < *pOriginalEnumsNum; i++)
         {
             aMenuEnums.emplace_back(originalEnums[i].prefID, originalEnums[i].name);
+
         }
         aMenuEnums.reserve(aMenuEnums.size() * 2);
         auto firstEnumCustomID = aMenuEnums.back().prefID + 1;
@@ -381,6 +382,12 @@ public:
         enum eAntialiasingText { eLow, eMedium, eHigh, eVeryHigh, eHighest, eMO_OFF, eFXAA, eSMAA };
         std::vector<const char*> data = { "Low", "Medium", "High", "Very High", "Highest", "MO_OFF", "FXAA", "SMAA" };
     } AntialiasingText;
+
+    struct
+    {
+        enum eAlwaysRunText { eLow, eMedium, eHigh, eMO_OFF, eOn, eOutside };
+        std::vector<const char*> data = { "Low", "Medium", "High","MO_OFF", "On", "Outside" };
+    } AlwaysRunText;
 
 } FusionFixSettings;
 

--- a/source/settings.ixx
+++ b/source/settings.ixx
@@ -30,8 +30,8 @@ private:
         auto SetValue(auto v) { value = v; WriteToIni(); if (callback) callback(value); }
         auto ReadFromIni(auto& iniReader) { return iniReader.ReadInteger(iniSec, iniName, iniDefValInt); }
         auto ReadFromIni() { CIniReader iniReader(cfgPath); return ReadFromIni(iniReader); }
-        void WriteToIni(auto& iniWriter) { iniWriter.WriteInteger(iniSec, iniName, value); }
-        void WriteToIni() { CIniReader iniWriter(cfgPath); iniWriter.WriteInteger(iniSec, iniName, value); }
+        void WriteToIni(auto& iniWriter) { iniWriter.WriteInteger(iniSec, iniName, value, true); }
+        void WriteToIni() { CIniReader iniWriter(cfgPath); iniWriter.WriteInteger(iniSec, iniName, value, true); }
     };
 
     struct MenuPrefs

--- a/source/settings.ixx
+++ b/source/settings.ixx
@@ -29,9 +29,9 @@ private:
         auto GetValue() { return value; }
         auto SetValue(auto v) { value = v; WriteToIni(); if (callback) callback(value); }
         auto ReadFromIni(auto& iniReader) { return iniReader.ReadInteger(iniSec, iniName, iniDefValInt); }
-        auto ReadFromIni() { CIniReader iniReader(cfgPath.wstring()); return ReadFromIni(iniReader); }
+        auto ReadFromIni() { CIniReader iniReader(cfgPath); return ReadFromIni(iniReader); }
         void WriteToIni(auto& iniWriter) { iniWriter.WriteInteger(iniSec, iniName, value); }
-        void WriteToIni() { CIniReader iniWriter(cfgPath.wstring()); iniWriter.WriteInteger(iniSec, iniName, value); }
+        void WriteToIni() { CIniReader iniWriter(cfgPath); iniWriter.WriteInteger(iniSec, iniName, value); }
     };
 
     struct MenuPrefs
@@ -134,7 +134,7 @@ public:
         pattern = find_pattern("89 1C 95 ? ? ? ? E8 ? ? ? ? A1 ? ? ? ? 83 C4 04 8D 04 40", "89 1C 8D ? ? ? ? E8 ? ? ? ? A1 ? ? ? ? 8D 0C 40 8B 14 CD");
         mPrefs = *pattern.get_first<int32_t*>(3);
 
-        CIniReader iniReader(cfgPath.wstring());
+        CIniReader iniReader(cfgPath);
 
         static CSetting arr[] = {
             { 0, "PREF_SKIP_INTRO",        "MAIN",       "SkipIntro",                       "",                           1, nullptr, 0, 1 },
@@ -164,7 +164,7 @@ public:
             { 0, "PREF_LETTERBOX",         "MISC",       "Letterbox",                       "",                           1, nullptr, 0, 1 },
             { 0, "PREF_PILLARBOX",         "MISC",       "Pillarbox",                       "",                           1, nullptr, 0, 1 },
             { 0, "PREF_ANTIALIASING",      "MISC",       "Antialiasing",                    "MENU_DISPLAY_ANTIALIASING",  1, nullptr, AntialiasingText.eMO_OFF, std::distance(std::begin(AntialiasingText.data), std::end(AntialiasingText.data)) - 1 },
-            { 0, "PREF_ALWAYSRUN",         "MISC",       "AlwaysRun",                       "MENU_DISPLAY_ALWAYSRUN",     1, nullptr, AlwaysRunText.eMO_OFF, std::distance(std::begin(AlwaysRunText.data), std::end(AlwaysRunText.data)) - 1  },
+            { 0, "PREF_ALWAYSRUN",         "MISC",       "AlwaysRun",                       "MENU_DISPLAY_ALWAYSRUN",     3, nullptr, AlwaysRunText.eMO_OFF, std::distance(std::begin(AlwaysRunText.data), std::end(AlwaysRunText.data)) - 1  },
         };
 
         auto i = firstCustomID;
@@ -385,8 +385,8 @@ public:
 
     struct
     {
-        enum eAlwaysRunText { eLow, eMedium, eHigh, eMO_OFF, eOn, eOutside };
-        std::vector<const char*> data = { "Low", "Medium", "High","MO_OFF", "On", "Outside" };
+        enum eAlwaysRunText { eLow, eMedium, eHigh, eMO_OFF, eMO_ON, eOutside };
+        std::vector<const char*> data = { "Low", "Medium", "High", "MO_OFF", "MO_ON", "Outside" };
     } AlwaysRunText;
 
 } FusionFixSettings;


### PR DESCRIPTION
Adds an option to the "Always Run" setting that makes it work only while not in interiors. This makes it easier to navigate in small interiors, like gun shops, without manually switching to walking.

[Video demonstration](https://www.youtube.com/watch?v=mi1jC8gJgOU)