### PR TITLE
Make values of menu options translatable, fix some small nitpicks

### DIFF
--- a/data/update/TBoGT/common/data/frontend_menus.xml
+++ b/data/update/TBoGT/common/data/frontend_menus.xml
@@ -367,8 +367,8 @@
       <options text="MO_DEF" action="ACTION_NONE" value="1" />
       <options text="MO_OFF" action="ACTION_NONE" value="2" />
       <options text="IV" action="ACTION_NONE" value="3" />
-      <options text="TLAD" action="ACTION_NONE" value="4" />
-      <options text="TBOGT" action="ACTION_NONE" value="5" />
+      <options text="TLaD" action="ACTION_NONE" value="4" />
+      <options text="TBoGT" action="ACTION_NONE" value="5" />
     </menupc>
     <menupc enum="MENU_DISPLAY_FRAMELIMIT">
       <options text="MO_OFF" action="ACTION_NONE" value="0" />
@@ -393,10 +393,10 @@
     <menupc enum="MENU_DISPLAY_DOF">
       <options text="MO_OFF" action="ACTION_NONE" value="1" />
       <options text="Cutscenes Only" action="ACTION_NONE" value="2" />
-      <options text="Low" action="ACTION_NONE" value="3" />
-      <options text="Medium" action="ACTION_NONE" value="4" />
-      <options text="High" action="ACTION_NONE" value="5" />
-      <options text="Very High" action="ACTION_NONE" value="6" />
+      <options text="MO_LOW" action="ACTION_NONE" value="3" />
+      <options text="MO_MED" action="ACTION_NONE" value="4" />
+      <options text="MO_HIGH" action="ACTION_NONE" value="5" />
+      <options text="MO_VHIGH" action="ACTION_NONE" value="6" />
     </menupc>
     <menupc enum="MENU_DISPLAY_TREE_LIGHTING">
       <options text="PC" action="ACTION_NONE" value="1" />
@@ -410,9 +410,9 @@
     <menupc enum="MENU_DISPLAY_BUTTONS">
       <options text="Xbox 360" action="ACTION_NONE" value="1" />
       <options text="Xbox One" action="ACTION_NONE" value="2" />
-      <options text="Playstation 3" action="ACTION_NONE" value="3" />
-      <options text="Playstation 4" action="ACTION_NONE" value="4" />
-      <options text="Playstation 5" action="ACTION_NONE" value="5" />
+      <options text="PlayStation 3" action="ACTION_NONE" value="3" />
+      <options text="PlayStation 4" action="ACTION_NONE" value="4" />
+      <options text="PlayStation 5" action="ACTION_NONE" value="5" />
       <options text="Nintendo Switch" action="ACTION_NONE" value="6" />
       <options text="Steam Deck" action="ACTION_NONE" value="7" />
       <options text="SteamController" action="ACTION_NONE" value="8" />

--- a/data/update/TLAD/common/data/frontend_menus.xml
+++ b/data/update/TLAD/common/data/frontend_menus.xml
@@ -443,8 +443,8 @@
       <options text="MO_DEF" action="ACTION_NONE" value="1" />
       <options text="MO_OFF" action="ACTION_NONE" value="2" />
       <options text="IV" action="ACTION_NONE" value="3" />
-      <options text="TLAD" action="ACTION_NONE" value="4" />
-      <options text="TBOGT" action="ACTION_NONE" value="5" />
+      <options text="TLaD" action="ACTION_NONE" value="4" />
+      <options text="TBoGT" action="ACTION_NONE" value="5" />
     </menupc>
     <menupc enum="MENU_DISPLAY_FRAMELIMIT">
       <options text="MO_OFF" action="ACTION_NONE" value="0" />
@@ -469,10 +469,10 @@
     <menupc enum="MENU_DISPLAY_DOF">
       <options text="MO_OFF" action="ACTION_NONE" value="1" />
       <options text="Cutscenes Only" action="ACTION_NONE" value="2" />
-      <options text="Low" action="ACTION_NONE" value="3" />
-      <options text="Medium" action="ACTION_NONE" value="4" />
-      <options text="High" action="ACTION_NONE" value="5" />
-      <options text="Very High" action="ACTION_NONE" value="6" />
+      <options text="MO_LOW" action="ACTION_NONE" value="3" />
+      <options text="MO_MED" action="ACTION_NONE" value="4" />
+      <options text="MO_HIGH" action="ACTION_NONE" value="5" />
+      <options text="MO_VHIGH" action="ACTION_NONE" value="6" />
     </menupc>
     <menupc enum="MENU_DISPLAY_TREE_LIGHTING">
       <options text="PC" action="ACTION_NONE" value="1" />
@@ -486,9 +486,9 @@
     <menupc enum="MENU_DISPLAY_BUTTONS">
       <options text="Xbox 360" action="ACTION_NONE" value="1" />
       <options text="Xbox One" action="ACTION_NONE" value="2" />
-      <options text="Playstation 3" action="ACTION_NONE" value="3" />
-      <options text="Playstation 4" action="ACTION_NONE" value="4" />
-      <options text="Playstation 5" action="ACTION_NONE" value="5" />
+      <options text="PlayStation 3" action="ACTION_NONE" value="3" />
+      <options text="PlayStation 4" action="ACTION_NONE" value="4" />
+      <options text="PlayStation 5" action="ACTION_NONE" value="5" />
       <options text="Nintendo Switch" action="ACTION_NONE" value="6" />
       <options text="Steam Deck" action="ACTION_NONE" value="7" />
       <options text="SteamController" action="ACTION_NONE" value="8" />
@@ -498,6 +498,7 @@
       <options text="FXAA" action="ACTION_NONE" value="2" />
       <options text="SMAA" action="ACTION_NONE" value="3" />
     </menupc>
+
   </sMenuDisplayValue>
   <sMenuScreen>
     <menu HeaderText="MH_GAM" enum="SCR_GAME">

--- a/data/update/common/data/frontend_menus.xml
+++ b/data/update/common/data/frontend_menus.xml
@@ -295,8 +295,8 @@
             <options text="MO_DEF" action="ACTION_NONE" value="1" />
             <options text="MO_OFF" action="ACTION_NONE" value="2" />
             <options text="IV" action="ACTION_NONE" value="3" />
-            <options text="TLAD" action="ACTION_NONE" value="4" />
-            <options text="TBOGT" action="ACTION_NONE" value="5" />
+            <options text="TLaD" action="ACTION_NONE" value="4" />
+            <options text="TBoGT" action="ACTION_NONE" value="5" />
         </menupc>
 
         <menupc enum="MENU_DISPLAY_FRAMELIMIT">
@@ -324,10 +324,10 @@
         <menupc enum="MENU_DISPLAY_DOF">
           <options text="MO_OFF" action="ACTION_NONE" value="1" />
           <options text="Cutscenes Only" action="ACTION_NONE" value="2" />
-          <options text="Low" action="ACTION_NONE" value="3" />
-          <options text="Medium" action="ACTION_NONE" value="4" />
-          <options text="High" action="ACTION_NONE" value="5" />
-          <options text="Very High" action="ACTION_NONE" value="6" />
+          <options text="MO_LOW" action="ACTION_NONE" value="3" />
+          <options text="MO_MED" action="ACTION_NONE" value="4" />
+          <options text="MO_HIGH" action="ACTION_NONE" value="5" />
+          <options text="MO_VHIGH" action="ACTION_NONE" value="6" />
         </menupc>
 
         <menupc enum="MENU_DISPLAY_TREE_LIGHTING">
@@ -344,9 +344,9 @@
         <menupc enum="MENU_DISPLAY_BUTTONS">
           <options text="Xbox 360" action="ACTION_NONE" value="1" />
           <options text="Xbox One" action="ACTION_NONE" value="2" />
-          <options text="Playstation 3" action="ACTION_NONE" value="3" />
-          <options text="Playstation 4" action="ACTION_NONE" value="4" />
-          <options text="Playstation 5" action="ACTION_NONE" value="5" />
+          <options text="PlayStation 3" action="ACTION_NONE" value="3" />
+          <options text="PlayStation 4" action="ACTION_NONE" value="4" />
+          <options text="PlayStation 5" action="ACTION_NONE" value="5" />
           <options text="Nintendo Switch" action="ACTION_NONE" value="6" />
           <options text="Steam Deck" action="ACTION_NONE" value="7" />
           <options text="SteamController" action="ACTION_NONE" value="8" />
@@ -368,10 +368,10 @@
             <options action="MENUOPT_ADJUST" label="MO_REPLAY" value="PREF_REPLAY_MODE" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <options action="MENUOPT_JUMP_GUIDE" label="MO_GUIDE" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             <options action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
-            <optionspc action="MENUOPT_ADJUST_GAMEMODE" label="Skip Intro" value="PREF_SKIP_INTRO" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
-            <optionspc action="MENUOPT_ADJUST_GAMEMODE" label="Skip Menu" value="PREF_SKIP_MENU" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+            <optionspc action="MENUOPT_ADJUST" label="Skip Intro" value="PREF_SKIP_INTRO" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+            <optionspc action="MENUOPT_ADJUST" label="Skip Menu" value="PREF_SKIP_MENU" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <optionspc action="MENUOPT_ADJUST" label="Windowed" value="PREF_WINDOWED" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
-            <optionspc action="MENUOPT_ADJUST_GAMEMODE" label="Borderless" value="PREF_BORDERLESS" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
+            <optionspc action="MENUOPT_ADJUST" label="Borderless" value="PREF_BORDERLESS" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <optionspc action="MENUOPT_ADJUST" label="Focus Loss" value="PREF_BLOCKONLOSTFOCUS" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <optionspc action="MENUOPT_ADJUST" label="LightSyncRGB" value="PREF_LEDILLUMINATION" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />
             <optionspc action="MENUOPT_ADJUST" label="FPS Counter" value="PREF_FPSCOUNTER" scaler="2" displayValue="MENU_DISPLAY_ON_OFF" />

--- a/text/americanFF.txt
+++ b/text/americanFF.txt
@@ -29,7 +29,7 @@ Cutscene Pillarbox
 Alternate Dialogues
 
 [Check Updates]
-Check For Fusion Fix Updates
+Check For FusionFix Updates
 
 [Raw Input]
 Raw Input
@@ -59,7 +59,7 @@ Console Gamma
 Screen Filter
 
 [Depth of Field]
-Depth of Field
+Depth Of Field
 
 [TreeFX]
 Tree Lighting
@@ -68,10 +68,13 @@ Tree Lighting
 Sun Shafts
 
 [Antialiasing]
-Anti-aliasing
+Anti-Aliasing
 
 [FPS Limiter]
 FPS Limiter
+
+[MO_FOV]
+Field Of View
 
 [LamppostShadows]
 Lamppost Shadows
@@ -85,14 +88,17 @@ Shadow Filter
 [HeadlightShadow]
 Headlight Shadows
 
+[MO_SHADOWDEN]
+Night Shadow Quality
+
 [FF_WARN0]
-~p~IMG Files:
+~p~IMG Archives:
 
 [FF_WARN1]
-; ~r~WARNING: 255 IMG limit exceeded, will cause streaming issues.
+; ~r~WARNING: 255 IMG archive limit exceeded, will cause streaming issues.
 
 [FF_WARN2]
-~r~WARNING: Lamppost shadows may cause visual artifacts and performance issues.
+~r~WARNING: Lamppost Shadows may cause visual artifacts and performance issues.
 
 [FF_WARN3]
 ~r~WARNING: View Distance slider above 25 and Detail Distance slider above 31 may cause object pop-in.
@@ -105,6 +111,30 @@ Headlight Shadows
 
 [FF_WARN6]
 ~r~WARNING: CHSS only takes effect with Shadow Quality set to Very High.
+
+[Custom]
+Custom
+
+[Sharp]
+Sharp
+
+[Soft]
+Soft
+
+[Cutscenes Only]
+Cutscenes Only
+
+[PC]
+PC
+
+[PC+]
+PC+
+
+[Console]
+Console
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.

--- a/text/frenchFF.txt
+++ b/text/frenchFF.txt
@@ -73,6 +73,9 @@ Anticrénelage
 [FPS Limiter]
 Limiteur de FPS
 
+[MO_FOV]
+
+
 [LamppostShadows]
 Ombres de réverbères
 
@@ -84,6 +87,9 @@ Filtre d'ombre
 
 [HeadlightShadow]
 Ombres des phares
+
+[MO_SHADOWDEN]
+
 
 [FF_WARN0]
 ~p~Fichiers IMG:
@@ -105,6 +111,30 @@ Ombres des phares
 
 [FF_WARN6]
 ~r~AVERTISSEMENT : CHSS ne fonctionne qu'avec la Qualité des Ombres réglée sur Très Élevée.
+
+[Custom]
+
+
+[Sharp]
+
+
+[Soft]
+
+
+[Cutscenes Only]
+
+
+[PC]
+
+
+[PC+]
+
+
+[Console]
+
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.

--- a/text/germanFF.txt
+++ b/text/germanFF.txt
@@ -29,7 +29,7 @@ Pillarbox-Balken in Zwischensequenzen
 Alternative Dialoge
 
 [Check Updates]
-Auf Fusion-Fix-Updates prüfen
+Auf FusionFix-Updates prüfen
 
 [Raw Input]
 Raw Input
@@ -73,6 +73,9 @@ Kantenglättung
 [FPS Limiter]
 FPS-Begrenzung
 
+[MO_FOV]
+
+
 [LamppostShadows]
 Straßenlaternen-Schatten
 
@@ -84,6 +87,9 @@ Schattenfilter
 
 [HeadlightShadow]
 Scheinwerfer-Schatten
+
+[MO_SHADOWDEN]
+
 
 [FF_WARN0]
 ~p~IMG-Dateien:
@@ -105,6 +111,30 @@ Scheinwerfer-Schatten
 
 [FF_WARN6]
 ~r~ACHTUNG: CHSS bewirkt nur etwas, wenn die Schattenqualität auf "Sehr hoch" eingestellt ist.
+
+[Custom]
+
+
+[Sharp]
+
+
+[Soft]
+
+
+[Cutscenes Only]
+
+
+[PC]
+
+
+[PC+]
+
+
+[Console]
+
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.

--- a/text/italianFF.txt
+++ b/text/italianFF.txt
@@ -29,7 +29,7 @@ Pillarbox del filmato
 Dialoghi alternativi
 
 [Check Updates]
-Controlla aggiornamenti per Fusion Fix
+Controlla aggiornamenti per FusionFix
 
 [Raw Input]
 Raw Input
@@ -73,6 +73,9 @@ Antialiasing
 [FPS Limiter]
 Limitatore degli FPS
 
+[MO_FOV]
+
+
 [LamppostShadows]
 Ombre dei lampioni
 
@@ -84,6 +87,9 @@ Filtro delle ombre
 
 [HeadlightShadow]
 Ombre dei fari
+
+[MO_SHADOWDEN]
+
 
 [FF_WARN0]
 ~p~IMG Files:
@@ -105,6 +111,30 @@ Ombre dei fari
 
 [FF_WARN6]
 ~r~ATTENZIONE: CHSS ha effetto solo con la Qualità delle Ombre impostata su Molto Alta.
+
+[Custom]
+
+
+[Sharp]
+
+
+[Soft]
+
+
+[Cutscenes Only]
+
+
+[PC]
+
+
+[PC+]
+
+
+[Console]
+
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.

--- a/text/japaneseFF.txt
+++ b/text/japaneseFF.txt
@@ -29,7 +29,7 @@ FPSカウンター
 代替対話
 
 [Check Updates]
-Fusion Fixアップデートを確認する
+FusionFixアップデートを確認する
 
 [Raw Input]
 Raw Input
@@ -73,6 +73,9 @@ Raw Input
 [FPS Limiter]
 FPSリミッター
 
+[MO_FOV]
+
+
 [LamppostShadows]
 街灯の影
 
@@ -84,6 +87,9 @@ FPSリミッター
 
 [HeadlightShadow]
 ヘッドライトの影
+
+[MO_SHADOWDEN]
+
 
 [FF_WARN0]
 ~p~IMG ファイル:
@@ -105,6 +111,30 @@ FPSリミッター
 
 [FF_WARN6]
 ~r~警告: CHSS は影の品質を「最高」に設定した場合のみ有効になります。
+
+[Custom]
+
+
+[Sharp]
+
+
+[Soft]
+
+
+[Cutscenes Only]
+
+
+[PC]
+
+
+[PC+]
+
+
+[Console]
+
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.

--- a/text/russianFF.txt
+++ b/text/russianFF.txt
@@ -29,7 +29,7 @@ Logitech LightSync RGB
 Альтернативные диалоги
 
 [Check Updates]
-Fusion Fix: Проверять Обновления
+FusionFix: Проверять Обновления
 
 [Raw Input]
 Непосредственный ввод (мышь)
@@ -73,6 +73,9 @@ Fusion Fix: Проверять Обновления
 [FPS Limiter]
 Ограничитель кадров
 
+[MO_FOV]
+
+
 [LamppostShadows]
 Тени от фонарей
 
@@ -84,6 +87,9 @@ Fusion Fix: Проверять Обновления
 
 [HeadlightShadow]
 Тени от фар
+
+[MO_SHADOWDEN]
+
 
 [FF_WARN0]
 ~p~IMG Архивы:
@@ -105,6 +111,30 @@ Fusion Fix: Проверять Обновления
 
 [FF_WARN6]
 ~r~ПРЕДУПРЕЖДЕНИЕ: CHSS работает только при настройке качества теней на «Очень высоко».
+
+[Custom]
+
+
+[Sharp]
+
+
+[Soft]
+
+
+[Cutscenes Only]
+
+
+[PC]
+
+
+[PC+]
+
+
+[Console]
+
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.

--- a/text/spanishFF.txt
+++ b/text/spanishFF.txt
@@ -29,7 +29,7 @@ Barras laterales en escenas
 Diálogos alternativos
 
 [Check Updates]
-Buscar actualizaciones de Fusion Fix
+Buscar actualizaciones de FusionFix
 
 [Raw Input]
 Entrada directa
@@ -73,6 +73,9 @@ Suavizado de líneas
 [FPS Limiter]
 Limitador de FPS
 
+[MO_FOV]
+
+
 [LamppostShadows]
 Sombras de farolas
 
@@ -84,6 +87,9 @@ Filtro de sombras
 
 [HeadlightShadow]
 Sombras de faros
+
+[MO_SHADOWDEN]
+
 
 [FF_WARN0]
 ~p~Archivos IMG:
@@ -105,6 +111,30 @@ Sombras de faros
 
 [FF_WARN6]
 ~r~ATENCIÓN: CHSS se activa solamente con la calidad de las sombras puesta en "Muy alta".
+
+[Custom]
+
+
+[Sharp]
+
+
+[Soft]
+
+
+[Cutscenes Only]
+
+
+[PC]
+
+
+[PC+]
+
+
+[Console]
+
+
+[SteamController]
+Steam Controller
 
 [DUMMY_l11]
 Dummy label.


### PR DESCRIPTION
Values made translatable:

"Custom" frame limiter option
"Sharp" and "Soft" shadow filters
"Cutscenes Only" depth of field setting
"PC", "PC+" and "Console" tree lighting settings

For the rest of the depth of field settings the game's native labels were given

Completes https://github.com/ThirteenAG/GTAIV.EFLC.FusionFix/issues/657

Corrections / Small Fixes:

Added the label for "Steam Controller" gamepad icon type to the .gxt, since it can have correct spacing this way (doesn't need translation(?);

Corrected help texts of "Skip Intro", "Skip Menu" and "Windowed Borderless" options in IV, they were assigned a wrong action, MENUOPT_ADJUST_GAMEMODE instead of MENUOPT_ADJUST and said "Enter" instead of "Adjust";

Made FOV option translatable, was missing before;

Changed "Night Shadows" to "Night Shadow Quality" to make the option a bit more clear on what it does, given recent changes to the option's behavior;

Changed "IMG Files" counter to "IMG Archives" since it's more correct;

Corrected some cases of some settings' texts:

"TLAD" and "TBOGT" screen filters to "TLaD and TBoGT"; 
"Depth of Field" and "Anti-aliasing" to "Depth Of Field" and "Anti-Aliasing"; 
"Lamppost shadows" warning to "Lamppost Shadows"
"Check For Fusion Fix Updates" to "Check For FusionFix Updates"; 
"Playstation" button icons to "PlayStation".