### PR TITLE
Rephrase uncommon translation for "lampposts"

### DIFF
--- a/text/germanFF.txt
+++ b/text/germanFF.txt
@@ -77,10 +77,10 @@ FPS-Begrenzung
 Zusätzliche Nachtschatten
 
 [Lampposts]
-Laternenpfähle
+Straßenlaternen
 
 [LampostsHeadl]
-Laternenpfähle und Scheinwerfer
+Straßenlaternen und Scheinwerfer
 
 [Tree Alpha]
 Baumtransparenz


### PR DESCRIPTION
"Laternenpfähle" is a somewhat dated word in German, lampposts are usually refered to as "Straßenlaternen"