### PR TITLE
Improved Spanish translations (3) + Fixed Distant Lights setting not being translated

### DIFF
--- a/data/update/common/data/frontend_menus.xml
+++ b/data/update/common/data/frontend_menus.xml
@@ -544,7 +544,7 @@
             <optionspc action="MENUOPT_ADJUST" label="TreeFX" value="PREF_TREE_LIGHTING" scaler="9" displayValue="MENU_DISPLAY_TREE_LIGHTING" />
             <optionspc action="MENUOPT_ADJUST" label="Tree Alpha" value="PREF_TREEALPHA" scaler="6" displayValue="MENU_DISPLAY_TREEALPHA" />
             <optionspc action="MENUOPT_ADJUST" label="Screen Filter" value="PREF_TIMECYC" scaler="10" displayValue="MENU_DISPLAY_TIMECYC" />
-            <optionspc action="MENUOPT_ADJUST" label="LODLights" value="PREF_DISTANTLIGHTS" scaler="2" displayValue="MENU_DISPLAY_NETSTATS_TRUESKILLNAME" />
+            <optionspc action="MENUOPT_ADJUST" label="Distant Lights" value="PREF_DISTANTLIGHTS" scaler="2" displayValue="MENU_DISPLAY_NETSTATS_TRUESKILLNAME" />
             <options action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             
             <options action="MENUOPT_SET" label="MO_DEF" value="SET_DEFAULT_DISPLAY" scaler="0" displayValue="MENU_DISPLAY_NONE" />

--- a/data/update/common/data/frontend_menus.xml
+++ b/data/update/common/data/frontend_menus.xml
@@ -544,7 +544,7 @@
             <optionspc action="MENUOPT_ADJUST" label="TreeFX" value="PREF_TREE_LIGHTING" scaler="9" displayValue="MENU_DISPLAY_TREE_LIGHTING" />
             <optionspc action="MENUOPT_ADJUST" label="Tree Alpha" value="PREF_TREEALPHA" scaler="6" displayValue="MENU_DISPLAY_TREEALPHA" />
             <optionspc action="MENUOPT_ADJUST" label="Screen Filter" value="PREF_TIMECYC" scaler="10" displayValue="MENU_DISPLAY_TIMECYC" />
-            <optionspc action="MENUOPT_ADJUST" label="Distant Lights" value="PREF_DISTANTLIGHTS" scaler="2" displayValue="MENU_DISPLAY_NETSTATS_TRUESKILLNAME" />
+            <optionspc action="MENUOPT_ADJUST" label="LODLights" value="PREF_DISTANTLIGHTS" scaler="2" displayValue="MENU_DISPLAY_NETSTATS_TRUESKILLNAME" />
             <options action="MENUOPT_NONE" label="" value="PREF_NULL" scaler="0" displayValue="MENU_DISPLAY_NONE" />
             
             <options action="MENUOPT_SET" label="MO_DEF" value="SET_DEFAULT_DISPLAY" scaler="0" displayValue="MENU_DISPLAY_NONE" />

--- a/text/spanishFF.txt
+++ b/text/spanishFF.txt
@@ -74,13 +74,13 @@ Suavizado de líneas
 Limitador de FPS
 
 [ExtraNightShad]
-Sombras Nocturnas Adicionales
+Sombras nocturnas adicionales
 
 [Lampposts]
 Farolas
 
 [LampostsHeadl]
-Farolas y Faros
+Farolas y faros
 
 [Tree Alpha]
 Transparencia de árboles
@@ -110,25 +110,25 @@ Permitir movimiento con zoom
 Luces lejanas
 
 [CenteredVehCam]
-Cámara de Vehículo Centrada
+Cámara de vehículo centrada
 
 [CenteredFootCam]
-Cámara a Pie Centrada
+Cámara a pie centrada
 
 [Camera Shake]
-Temblor de Cámara
+Temblor de cámara
 
 [CutscAudioSync]
-Sincronización de Audio de Escenas
+Sincronización de audio en escenas
 
 [CutscAudioSync0]
-Sincronización de Audio de Escenas desactivada
+Sincronización de audio en escenas desactivada
 
 [CutscAudioSync1]
-Sincronización de Audio de Escenas activada
+Sincronización de audio en escenas activada
 
 [Turn Indicators]
-Indicadores de Giro
+Indicadores de giro
 
 [WinterEvent0]
 Evento de invierno desactivado
@@ -149,7 +149,7 @@ Evento de Halloween activado
 ; ~r~ATENCIÓN: Se ha sobrepasado el límite de 255 archivos IMG y causará problemas de carga ("streaming"). 
 
 [FF_WARN2]
-~r~ATENCIÓN: Sombras Nocturnas Adicionales es una opción original de PC de Rockstar. Muy defectuosa, no recomendada.
+~r~ATENCIÓN: "Sombras nocturnas adicionales" es una opción original de PC hecho por Rockstar. Muy defectuosa, no recomendada.
 
 [FF_WARN3]
 ~r~ATENCIÓN: Los valores de distancia visible superiores a 25 y los valores de detalle de distancia superiores a 31 pueden causar que los objetos se dibujen bruscamente ("pop-in").


### PR DESCRIPTION
Fixes some typos in Spanish in the new added options. It also fixes a bug where Distant Lights option is not translated.