### PR TITLE
Update color stuff

### DIFF
--- a/source/settings.ixx
+++ b/source/settings.ixx
@@ -293,7 +293,7 @@ public:
             { 0, "PREF_EXTRANIGHTSHADOWS",      "SHADOWS",    "ExtraNightShadows",               "",                           0, nullptr, 0, 3 }, //MENU_DISPLAY_NETSTATS_SCORES
             { 0, "PREF_GRAPHICSAPI",            "MAIN",       "GraphicsAPI",                     "",                           0, nullptr, 0, 1 }, //MENU_DISPLAY_NETSTATS_COMP_TEAM
             { 0, "PREF_BULLETTRACES",           "MISC",       "AlwaysShowBulletTraces",          "",                           0, nullptr, 0, 1 },
-            { 0, "PREF_AUTOEXPOSURE",           "MISC",       "ConsoleAutoExposure",             "",                           1, nullptr, 0, 1 },
+            { 0, "PREF_AUTOEXPOSURE",           "MISC",       "ConsoleAutoExposure",             "",                           0, nullptr, 0, 1 },
             // Enums are at capacity, to use more enums, replace multiplayer ones. On/Off toggles should still be possible to add.
         };
 


### PR DESCRIPTION
As much as the stronger console auto exposure is the intended look, most people would probably find the game to be excessively dark at times, especially TBOGT, so I disabled it by default.