### PR TITLE
PreCE patterns for extended limits (Weaponinfo and Vehoff disabled due to a bug and because I don't know if offsets in ReplaceXrefs are correct)

### DIFF
--- a/source/limits.ixx
+++ b/source/limits.ixx
@@ -495,31 +495,25 @@ public:
 
                 // WeaponInfo
                 {
-                    auto pattern = hook::pattern("81 C3 ? ? ? ? 89 03"); // Pattern hint: 81 C7 ? ? ? ? 89 07
+                    auto pattern = find_pattern("81 C3 ? ? ? ? 89 03", "81 C7 ? ? ? ? 89 07");
+                    auto ref1 = (intptr_t)find_pattern("BF ? ? ? ? 8D 64 24 00 8B CE E8 ? ? ? ? 81 C6 ? ? ? ? 4F 79 F0 68 ? ? ? ? E8 ? ? ? ? 83 C4 04 5F 5E C3 56").get_first(1);
+                    auto ref2 = (intptr_t)find_pattern("83 F8 3C 7C F1", "83 F8 3C 7C EF").get_first(2);
+                    auto WeaponInfo = LimitAdjuster(*pattern.get_first<uintptr_t>(2), 0x110, 60, 16).ReplaceXrefs(0, 0x24, 0x1A98, 0x1A9C, 0x1AB4, 0x1B30, 0x3430, 0x3540, 0x363C, 0x3870, 0x3980, 0x3DC0).ReplaceNumericRefs(ref1, ref2);
+                        
+                    pattern = hook::pattern("7D 0C 69 C0");
+                    injector::MakeNOP(pattern.get_first(), 2);
+
+                    pattern = find_pattern("C0 3B 0C 85 ? ? ? ? 74 0A 40", "C0 3B 0C 85 ? ? ? ? 74 0C");
                     if (!pattern.empty())
                     {
-                        auto ref1 = (intptr_t)hook::get_pattern("BF ? ? ? ? 8D 64 24 00 8B CE E8 ? ? ? ? 81 C6 ? ? ? ? 4F 79 F0 68 ? ? ? ? E8 ? ? ? ? 83 C4 04 5F 5E C3 56", 1); // Pattern hint: BE ? ? ? ? EB 03 8D 49 00 E8 ? ? ? ? 81 C1 ? ? ? ? 83 EE 01 79 F0 68 ? ? ? ? E8 ? ? ? ? 83 C4 04 5E C3
-                        auto ref2 = (intptr_t)hook::get_pattern("83 F8 3C 7C F1", 2); //Pattern hint: 83 F8 3C 7C EF
-                        auto WeaponInfo = LimitAdjuster(*pattern.get_first<uintptr_t>(2), 0x110, 60, 16).ReplaceXrefs(0, 0x24, 0x1A98, 0x1A9C, 0x1AB4, 0x1B30, 0x3430, 0x3540, 0x363C, 0x3870, 0x3980, 0x3DC0).ReplaceNumericRefs(ref1, ref2);
-                        
-                        pattern = hook::pattern("7D 0C 69 C0");
-                        injector::MakeNOP(pattern.get_first(), 2);
-
-                        pattern = find_pattern("C0 3B 0C 85 ? ? ? ? 74 0A 40", "C0 3B 0C 85 ? ? ? ? 74 0C");
-                        if (!pattern.empty())
-                        {
-                            shGetWeaponInfoIdByHash = safetyhook::create_inline(pattern.get_first(-5), getWeaponInfoIdByHash);
-                        }
+                        shGetWeaponInfoIdByHash = safetyhook::create_inline(pattern.get_first(-5), getWeaponInfoIdByHash);
                     }
                 }
 
                 // VehOff
                 {
-                    auto pattern = hook::pattern("81 C7 ? ? ? ? 83 BB"); // Pattern hint: 81 C7 ? ? ? ? 83 BE
-                    if (!pattern.empty())
-                    {
-                        auto VehOff = LimitAdjuster(*pattern.get_first<uintptr_t>(2), 640, 205, 6).ReplaceXrefs(0, 0x1C0, 0x1E0);
-                    }
+                    auto pattern = find_pattern("81 C7 ? ? ? ? 83 BB", "81 C7 ? ? ? ? 83 BE");
+                    auto VehOff = LimitAdjuster(*pattern.get_first<uintptr_t>(2), 640, 205, 6).ReplaceXrefs(0, 0x1C0, 0x1E0);
                 }
             }
         };


### PR DESCRIPTION
VehOff causes a bug when shooting a driver/passenger and then entering the vehicle from their side. The corpse to still be there despite animation of throwing them out  playing. The corpse will perform getting hurt animation and player will just enter into them. The player won't be in control of the car and won't be able to get out.