### PR TITLE
new Cheatcode for another unused IV hair

### DIFF
--- a/source/cheats.ixx
+++ b/source/cheats.ixx
@@ -157,12 +157,47 @@ public:
                     {
                         auto Hair = Natives::GetCharDrawableVariation(PlayerPed, PED_COMPONENT_HAIR);
 
-                        if (!Hair)
+                        if (Hair == 0)
                         {
                             Natives::SetCharComponentVariation(PlayerPed, PED_COMPONENT_HAIR, 1, 0);
                             Natives::PrintHelp((char*)"CHEAT1");
                         }
-                        else
+                        if (Hair == 1)
+                        {
+                            Natives::SetCharComponentVariation(PlayerPed, PED_COMPONENT_HAIR, 0, 0);
+                            Natives::PrintHelp((char*)"CHEAT2");
+                        }
+                        if (Hair == 2)
+                        {
+                            Natives::SetCharComponentVariation(PlayerPed, PED_COMPONENT_HAIR, 1, 0);
+                            Natives::PrintHelp((char*)"CHEAT1");
+                        }
+                    }
+                }
+            });
+
+            //Another Unused IV Hair
+            NativeOverride::RegisterPhoneCheat("5285550100", []
+            {
+                if (*_dwCurrentEpisode == 0)
+                {
+                    Ped PlayerPed = 0;
+                    Natives::GetPlayerChar(Natives::ConvertIntToPlayerIndex(Natives::GetPlayerId()), &PlayerPed);
+                    if (PlayerPed)
+                    {
+                        auto Hair = Natives::GetCharDrawableVariation(PlayerPed, PED_COMPONENT_HAIR);
+
+                        if (Hair == 0)
+                        {
+                            Natives::SetCharComponentVariation(PlayerPed, PED_COMPONENT_HAIR, 2, 0);
+                            Natives::PrintHelp((char*)"CHEAT1");
+                        }
+                        if (Hair == 1)
+                        {
+                            Natives::SetCharComponentVariation(PlayerPed, PED_COMPONENT_HAIR, 2, 0);
+                            Natives::PrintHelp((char*)"CHEAT1");
+                        }
+                        if (Hair == 2)
                         {
                             Natives::SetCharComponentVariation(PlayerPed, PED_COMPONENT_HAIR, 0, 0);
                             Natives::PrintHelp((char*)"CHEAT2");


### PR DESCRIPTION
In the original IV game, aside from the beta hairstyle that appeared in GTAIV trailer, Niko seems to have another unused hairstyle, which looks much shorter compared to the vanilla hair and somewhat resembles Packie's hairstyle. Based on your original cheats.ixx code which adds a new cheatcode to bring back Niko's beta hairstyle, I wrote another new cheat code to use this unused hairstyle for Niko, and slightly modified original cheats.ixx code's "if condition" to ensure that the two cheat codes don't interfere with each other. There should be no problem, but since I'm still a beginner in programming, I hope you can double-check to make sure everything is fine.

<img width="2559" height="1430" alt="Another Unused IV Hair" src="https://github.com/user-attachments/assets/57cfcbdd-8f6e-4eaf-8633-5a28948cb87e" />
