### PR TITLE
Fix snow volumes' distant fading

### DIFF
--- a/source/seasonal/snow.ixx
+++ b/source/seasonal/snow.ixx
@@ -117,14 +117,9 @@ public:
         pRainEmitter = *pattern.get_first<gtaRainEmitter*>(15);
         pStormEmitter = reinterpret_cast<gtaRainEmitter*>((uintptr_t)pRainEmitter + 0xD0);
 
-        pattern = hook::pattern("F3 0F 11 05 ? ? ? ? 66 0F 6E 05 ? ? ? ? 0F 5B C0 F3 0F 59 05 ? ? ? ? F3 0F 59 05 ? ? ? ? F3 0F 58 05 ? ? ? ? F3 0F 11 04 24");
+        pattern = find_pattern("F3 0F 11 05 ? ? ? ? 66 0F 6E 05 ? ? ? ? 0F 5B C0 F3 0F 59 05 ? ? ? ? F3 0F 59 05 ? ? ? ? F3 0F 58 05 ? ? ? ? F3 0F 11 04 24", "F3 0F 11 05 ? ? ? ? F3 0F 2A 05 ? ? ? ? F3 0F 59 05 ? ? ? ? F3 0F 58 05 ? ? ? ? D3 E6");
         if (!pattern.empty())
         {
-            dwViewDistance = *pattern.get_first<float*>(4);
-        }
-        else
-        {
-            pattern = hook::pattern("F3 0F 11 05 ? ? ? ? F3 0F 2A 05 ? ? ? ? F3 0F 59 05 ? ? ? ? F3 0F 58 05 ? ? ? ? D3 E6");
             dwViewDistance = *pattern.get_first<float*>(4);
         }
     }


### PR DESCRIPTION
Fade distances should be scaled by the View Distance slider for more consistency across settings.

Also adjusted the fade distances to somewhat fit the vanilla light models' light distance caps with this extra scaling.