### PR TITLE
Console Gamma capping HDR luminance at whitepoint FIX

### DIFF
--- a/source/resources/PS_BlitGamma.asm
+++ b/source/resources/PS_BlitGamma.asm
@@ -57,6 +57,6 @@
     dp2add r0.w, r1.xy, c3.xy, c3.w
     frc r0.w, r0.w
     add r0.w, r0.w, c4.x
-    mad_sat oC0.xyz, r0.w, c4.y, r0.xyz
+    mad oC0.xyz, r0.w, c4.y, r0.xyz
 
 // approximately 27 instruction slots used (1 texture, 26 arithmetic)


### PR DESCRIPTION
mad_sat clamps the ouput color to [0,1] preventing DXVK from outputting values above SDR whitepoint, effectively preventing the game from rendering native HDR.

Changing mad_sat to mad removes the clamp and restores proper luminance output without affecting SDR behavior.

How to reproduce: 

-Use d3d9.dll and the experimental config file from the DXVK HDR mod by EndlesslyFlowering
-Use Reshade HDR shaders by Lilium to map SDR to HDR, change "overbright bits handling" to "apply gamma" and SDR whitepoint to 203 nits.
-Use the HDR analysis tool to track the brightness curve.

Before and after illustrated below:

<img width="3840" height="2160" alt="HDR curve before fix" src="https://github.com/user-attachments/assets/192ccbcb-dd79-4698-ab31-3ef9929df1b4" />
<img width="3840" height="2160" alt="HDR curve after fix" src="https://github.com/user-attachments/assets/b5b15896-bc94-424e-a7e9-5d5271188857" />