### PR TITLE
fix brake lights for players vehicles when stopped

### DIFF
--- a/data/plugins/GTAIV.EFLC.FusionFix.ini
+++ b/data/plugins/GTAIV.EFLC.FusionFix.ini
@@ -30,6 +30,7 @@ DisableCameraCenteringInCover = 1             // disables the forced camera cent
 ExtraInfo = 1                                 // shows extra info in the pause menu (e.g. loaded img files amount)
 OverrideTreeAlpha = 0.0                       // set to e.g. 0.625, 2.5 or 4.0 for PC, PS3 or X360 tree alpha, respectively
 ConsoleCarReflectionsAndDirt = 1              // use stronger console car reflections and any cars can be dirty when they are spawned like console
+BrakeLightsWhenStopped = 1                    // lights the players brake lamps while stopped, like AI vehicles do (vanilla only lights them above walking pace)
 AlwaysDisplayHealthOnReticle = 1              // allow game to display NPC health on the reticle when playing with keyboard and mouse
 SmoothShorelines = 1                          // makes water edges smooth and adjusts foam noise
 SmoothLightVolumes = 1                        // makes light volume edges smooth

--- a/source/brakelights.ixx
+++ b/source/brakelights.ixx
@@ -1,0 +1,63 @@
+module;
+
+#include <common.hxx>
+#include <cmath>
+
+export module brakelights;
+
+import common;
+import comvars;
+
+static constexpr float fStoppedSpeed = 0.5f; // matches the games own pedal split threshold
+static constexpr float fIdleThrottle = 0.01f;
+
+static float GetForwardSpeed(uintptr_t pVehicle)
+{
+    float vecSpeed[4]{};
+    float vecOffset[4]{};
+    CPhysical::GetLocalSpeed((void*)pVehicle, nullptr, vecSpeed, vecOffset, 0, 0);
+
+    auto matrix = *(float**)(pVehicle + 0x20);
+    return vecSpeed[0] * matrix[4] + vecSpeed[1] * matrix[5] + vecSpeed[2] * matrix[6];
+}
+
+class BrakeLights
+{
+public:
+    BrakeLights()
+    {
+        FusionFix::onInitEventAsync() += []()
+        {
+            CIniReader iniReader("");
+            if (!iniReader.ReadInteger("MISC", "BrakeLightsWhenStopped", 1))
+                return;
+
+            auto pattern = find_pattern("F3 0F 10 86 ? ? 00 00 0F 2F 05 ? ? ? ? 77 ? 80 FE 01 75 ? 84 D2 75 ? 83 BE ? ? 00 00 00 74 ? F6 86 ? ? 00 00 08");
+            if (pattern.empty() || !CPlayer::getLocalPlayerPed || !CPhysical::GetLocalSpeed)
+                return;
+
+            static const ptrdiff_t nBrakePedal = *pattern.get_first<uint32_t>(4);
+            static const ptrdiff_t nGasPedal = nBrakePedal - sizeof(float);
+            static const ptrdiff_t nDriver = *pattern.get_first<uint32_t>(28);
+
+            static auto BrakeLightTestHook = safetyhook::create_mid(pattern.get_first(8), [](SafetyHookContext& regs)
+            {
+                if (regs.xmm0.f32[0] > 0.1f)
+                    return; // already braking, vanilla handles it
+
+                auto pVehicle = static_cast<uintptr_t>(regs.esi);
+                auto pDriver = *(uintptr_t*)(pVehicle + nDriver);
+                if (!pDriver || pDriver != CPlayer::getLocalPlayerPed())
+                    return; // AI vehicles already light theirs correctly
+
+                if (*(float*)(pVehicle + nGasPedal) > fIdleThrottle)
+                    return; // pulling away
+
+                if (std::fabs(GetForwardSpeed(pVehicle)) >= fStoppedSpeed)
+                    return; // still rolling, or reversing under power
+
+                regs.xmm0.f32[0] = 1.0f;
+            });
+        };
+    }
+} BrakeLights;


### PR DESCRIPTION
Fixes the players vehicle brake lights so when stationary, they are on like NPC vehicles

closes https://github.com/ThirteenAG/GTAIV.EFLC.FusionFix/issues/1386