### PR TITLE
Scale rear heli rotor break increment by timestep

### DIFF
--- a/source/frameratevigilante.ixx
+++ b/source/frameratevigilante.ixx
@@ -1013,6 +1013,15 @@ public:
                         {
                             regs.xmm2.f32[0] *= regs.xmm0.f32[0] * *CTimer::fTimeStep / (1.0f / 30.0f);
                         });
+
+                        // Scale the addend (mulss xmm0, [rate]; addss xmm2, xmm0) like main rotors.
+                        // Hook2 only scaled xmm2 *= xmm0; the per-frame increment stayed fps-dependent.
+                        static auto rear_break_rate = *pattern.get_first<float*>(14);
+                        injector::MakeNOP(pattern.get_first(10), 8, true);
+                        static auto CHeli__ApplyCollisionInternal_Hook2b = safetyhook::create_mid(pattern.get_first(10), [](SafetyHookContext& regs)
+                        {
+                            regs.xmm0.f32[0] *= *rear_break_rate * *CTimer::fTimeStep / (1.0f / 30.0f);
+                        });
                     }
                     else
                     {


### PR DESCRIPTION
## What
Main rotors in `frameratevigilante.ixx` scale `mulss xmm2, [rate]` by `fTimeStep / (1/30)` so break time stays ~10s at high FPS.

Rear rotors only scaled `mulss xmm2, xmm0` (Hook2). The following increment:

```
mulss xmm0, [rate]
addss xmm2, xmm0
```

was still per-frame, so tail break time stayed FPS-dependent (v5.0.1 changelog: *rear ones are still inconsistent*).

Hook2b applies the **same recipe as main rotors** to that `mulss xmm0, [rate]` (pattern offset +10 / imm +14).

## Test
Complete Edition, FusionFix limiter 60 vs 120, damage Annihilator/Maverick rotors. Main vs tail break time should match ~10s at both caps.

Untested in-game on my side (no GTA IV here). Draft-quality — happy to iterate.
